### PR TITLE
Replace last use of deprecated _.all() with _.every()

### DIFF
--- a/src/backbone.typeahead.coffee
+++ b/src/backbone.typeahead.coffee
@@ -112,7 +112,7 @@ class Backbone.TypeaheadCollection extends Backbone.Collection
     checkIfShortestList = (list) =>
       shortestList = list if list.length <= (shortestList?.length or @length)
 
-    _.all firstChars, (firstChar) =>
+    _.every firstChars, (firstChar) =>
       list = @_adjacency[firstChar]
 
       return false unless list?


### PR DESCRIPTION
The [lodash v4.0.0](https://github.com/lodash/lodash/wiki/Changelog#v400) release removed the `_.all()` alias in favor of [_.every()](https://lodash.com/docs/4.17.4#every).  This causes this library to fail when calling the core `typeahead()` query method.

This PR fixes it to call `_.every()` instead.