### PR TITLE
Fix main entry point in package.json to match bower.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
   ],
   "homepage": "https://github.com/mojotech/backbone.typeahead",
   "license": "MIT",
-  "main": "backbone.typeahead.min.js"
+  "main": "./dist/backbone.typeahead.min.js"
 }


### PR DESCRIPTION
This is required to get `backbone.typeahead` to work with [yarn](https://yarnpkg.com) and [webpack](https://webpack.github.io/).

Otherwise, doing this:

```javascript
require('backbone.typeahead');
```

results in: 

`Module not found: Error: Can't resolve 'backbone.typeahead'`

This will ensure the main entry point is similar to the one specified in your current [bower.json](https://github.com/mojotech/backbone.typeahead/blob/master/bower.json#L9).